### PR TITLE
Cherry-pick from telescope-ghq.nvim

### DIFF
--- a/lua/telescope/_extensions/repo_builtin.lua
+++ b/lua/telescope/_extensions/repo_builtin.lua
@@ -1,5 +1,6 @@
 local actions = require'telescope.actions'
 local actions_set = require'telescope.actions.set'
+local actions_state = require'telescope.actions.state'
 local conf = require'telescope.config'.values
 local entry_display = require'telescope.pickers.entry_display'
 local finders = require'telescope.finders'
@@ -122,7 +123,7 @@ M.list = function(opts)
     sorter = conf.file_sorter(opts),
     attach_mappings = function(prompt_bufnr)
       actions_set.select:replace(function(_, type)
-        local entry = actions.get_selected_entry()
+        local entry = actions_state.get_selected_entry()
         local dir = from_entry.path(entry)
         if type == 'default' then
           actions._close(prompt_bufnr, true)


### PR DESCRIPTION
Cherry-picked and adapted commits from the extension I originally forked from. Thanks @delphinus!

- Use Path.path.root() to detect the root
- Detect absolute paths
- Clean up source for arrange paths
- Avoid duplication messages

Going to test from this branch for a little bit before merging.
