### PR TITLE
fix(tests):  bad `Makefile` syntax, tests improved (closes #82)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-.PHONY: test, fmt, lint
+.PHONY: test fmt lint test_ci
 
 all: test lint
 
+test: test_ci
+
 test_ci:
-	@nvim --headless -c "PlenaryBustedDirectory lua/tests/ {}"
+	@nvim --clean --headless -c "PlenaryBustedDirectory lua/tests/ {}" -c "qa!"
 
 fmt:
 	@stylua lua

--- a/lua/tests/automated/list_command_spec.lua
+++ b/lua/tests/automated/list_command_spec.lua
@@ -1,13 +1,13 @@
 describe("integration tests: ", function()
     it("Telescope repo repo", function()
-        vim.cmd([[Telescope repo repo]])
+        vim.cmd.Telescope({ args = { "repo", "repo" } })
     end)
 
     it("Telescope repo list", function()
-        vim.cmd([[Telescope repo list]])
+        vim.cmd.Telescope({ args = { "repo", "list" } })
     end)
 
     it("Telescope repo cached_list", function()
-        vim.cmd([[Telescope repo cached_list]])
+        vim.cmd.Telescope({ args = { "repo", "cached_list" } })
     end)
 end)

--- a/lua/tests/automated/telescope_basics_spec.lua
+++ b/lua/tests/automated/telescope_basics_spec.lua
@@ -1,5 +1,5 @@
 describe("sanity check tests: ", function()
     it("Telescope builtin", function()
-        vim.cmd([[Telescope builtin]])
+        vim.cmd.Telescope("builtin")
     end)
 end)


### PR DESCRIPTION
## Description

See #82 for a detailed description of what was wrong. This PR closes #82.